### PR TITLE
Check for localhost before making requests

### DIFF
--- a/geoip.inc
+++ b/geoip.inc
@@ -160,6 +160,11 @@ static ResetState(playerid)
 hook OnPlayerConnect(playerid) {
 	new addr[16];
 	GetPlayerIp(playerid, addr);
+	
+	if (strequal(addr, "127.0.0.1")) {
+		return 1;
+	}
+
 	_geoip_doRequest(addr, playerid);
 	return 1;
 }


### PR DESCRIPTION
It will let us avoid running out of memory resulting in a server crash when we connect too many NPCs at once (or just hundreds of players).